### PR TITLE
Introduce a bloopConfig configuration by source set

### DIFF
--- a/src/main/scala/bloop/integrations/gradle/BloopParameters.scala
+++ b/src/main/scala/bloop/integrations/gradle/BloopParameters.scala
@@ -3,15 +3,15 @@ package bloop.integrations.gradle
 import java.io.File
 import java.util.ArrayList
 
+import scala.collection.JavaConverters._
+
 import bloop.integrations.gradle.syntax._
 
 import org.gradle.api.Project
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
-
-import scala.collection.JavaConverters._
-import org.gradle.api.provider.ListProperty
 
 /**
  * Project extension to configure Bloop.

--- a/src/main/scala/bloop/integrations/gradle/BloopParameters.scala
+++ b/src/main/scala/bloop/integrations/gradle/BloopParameters.scala
@@ -1,6 +1,7 @@
 package bloop.integrations.gradle
 
 import java.io.File
+import java.util.ArrayList
 
 import bloop.integrations.gradle.syntax._
 
@@ -8,6 +9,9 @@ import org.gradle.api.Project
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
+
+import scala.collection.JavaConverters._
+import org.gradle.api.provider.ListProperty
 
 /**
  * Project extension to configure Bloop.
@@ -21,6 +25,7 @@ import org.gradle.api.tasks.Optional
  *   stdLibName = "scala-library" // or "scala3-library_3"
  *   includeSources = true
  *   includeJavaDoc = false
+ *   extendUserConfigurations = ["myCustomMainConfig"]
  * }
  * }}}
  */
@@ -58,6 +63,13 @@ case class BloopParametersExtension(project: Project) {
   @Input @Optional def getIncludeJavadoc: Property[java.lang.Boolean] =
     includeJavadoc_
 
+  private val extendUserConfigurations_ : ListProperty[String] =
+    project.getObjects().listProperty(classOf[String])
+  extendUserConfigurations_.set(new ArrayList[String]())
+
+  @Input @Optional def getExtendUserConfigurations: ListProperty[String] =
+    extendUserConfigurations_
+
   def createParameters: BloopParameters = {
     val defaultTargetDir =
       project.getRootProject.workspacePath.resolve(".bloop").toFile
@@ -66,7 +78,8 @@ case class BloopParametersExtension(project: Project) {
       Option(compilerName_.getOrNull),
       Option(stdLibName_.getOrNull),
       includeSources_.get,
-      includeJavadoc_.get
+      includeJavadoc_.get,
+      extendUserConfigurations_.get.asScala.toList
     )
   }
 }
@@ -76,5 +89,6 @@ case class BloopParameters(
     compilerName: Option[String],
     stdLibName: Option[String],
     includeSources: Boolean,
-    includeJavadoc: Boolean
+    includeJavadoc: Boolean,
+    extendUserConfigurations: List[String]
 )

--- a/src/main/scala/bloop/integrations/gradle/BloopPlugin.scala
+++ b/src/main/scala/bloop/integrations/gradle/BloopPlugin.scala
@@ -1,11 +1,14 @@
 package bloop.integrations.gradle
 
 import bloop.integrations.gradle.syntax._
+import bloop.integrations.gradle.tasks.PluginUtils
 import bloop.integrations.gradle.tasks.BloopInstallTask
 import bloop.integrations.gradle.tasks.ConfigureBloopInstallTask
+import scala.collection.JavaConverters._
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSet
 import org.gradle.api.artifacts.Configuration
 
 /**
@@ -27,9 +30,84 @@ final class BloopPlugin extends Plugin[Project] {
       s"Applying bloop plugin to project ${project.getName}",
       Seq.empty: _*
     )
+
     project.createExtension[BloopParametersExtension]("bloop", project)
 
-    val bloopConfig = project.getConfigurations().create("bloopConfig")
+    project.afterEvaluate(
+      new org.gradle.api.Action[Project] {
+        def execute(project: Project): Unit = {
+
+          val bloopParams = project.getExtension[BloopParametersExtension].createParameters
+
+          if (PluginUtils.hasJavaScalaPlugin(project)) {
+            project.allSourceSets.foreach { sourceSet =>
+              val bloopConfigName = generateBloopConfigName(sourceSet)
+              val bloopConfig = createBloopConfigForSourceSet(bloopConfigName, project)
+              val compatibleConfigNames =
+                findCompatibleConfigNamesFromSourceSet(sourceSet) ++
+                  bloopParams.extendUserConfigurations
+
+              extendCompatibleConfigurationAfterEvaluate(
+                project,
+                bloopConfig,
+                compatibleConfigNames,
+                Set.empty
+              )
+            }
+          }
+
+          if (PluginUtils.hasAndroidPlugin(project)) {
+            // In the Android world, we don't have source sets for each variant, so instead
+            // we create an Android-specific configuration that we can use to resolve all
+            // relevant artifacts in all variants (the empty extend configs)
+            val bloopAndroidConfig = createBloopConfigForSourceSet("bloopAndroidConfig", project)
+
+            extendCompatibleConfigurationAfterEvaluate(
+              project,
+              bloopAndroidConfig,
+              Set.empty,
+              incompatibleAndroidConfigurations
+            )
+          }
+        }
+      }
+    )
+
+    // Creates two tasks: one to configure the plugin and the other one to generate the config files
+    val configureBloopInstall =
+      project.createTask[ConfigureBloopInstallTask]("configureBloopInstall")
+    val bloopInstall = project.createTask[BloopInstallTask]("bloopInstall")
+    configureBloopInstall.installTask = Some(bloopInstall)
+    bloopInstall.dependsOn(configureBloopInstall)
+    ()
+  }
+
+  private def findCompatibleConfigNamesFromSourceSet(sourceSet: SourceSet): Set[String] = Set(
+    sourceSet.getApiConfigurationName(),
+    sourceSet.getImplementationConfigurationName(),
+    sourceSet.getCompileOnlyConfigurationName(),
+    // sourceSet.getCompileOnlyApiConfigurationName(),
+    sourceSet.getCompileClasspathConfigurationName(),
+    sourceSet.getRuntimeOnlyConfigurationName(),
+    sourceSet.getRuntimeClasspathConfigurationName(),
+    sourceSet.getRuntimeElementsConfigurationName(),
+    "scalaCompilerPlugins"
+  )
+
+  private[this] val incompatibleAndroidConfigurations = Set[String](
+    "incrementalScalaAnalysisElements",
+    "incrementalScalaAnalysisFormain",
+    "incrementalScalaAnalysisFortest",
+    "incrementalScalaAnalysisForintegTest",
+    "incrementalScalaAnalysisForjmh",
+    "zinc"
+  )
+
+  private def createBloopConfigForSourceSet(
+      bloopConfigName: String,
+      project: Project
+  ): Configuration = {
+    val bloopConfig = project.getConfigurations().create(bloopConfigName)
     bloopConfig.setDescription(
       "A configuration for Bloop to be able to export artifacts in all other configurations."
     )
@@ -41,50 +119,34 @@ final class BloopPlugin extends Plugin[Project] {
     // This configuration is not meant to be consumed by other projects
     bloopConfig.setCanBeConsumed(false)
 
-    extendCompatibleConfigurationAfterEvaluate(project, bloopConfig)
-
-    // Creates two tasks: one to configure the plugin and the other one to generate the config files
-    val configureBloopInstall =
-      project.createTask[ConfigureBloopInstallTask]("configureBloopInstall")
-    val bloopInstall = project.createTask[BloopInstallTask]("bloopInstall")
-    configureBloopInstall.installTask = Some(bloopInstall)
-    bloopInstall.dependsOn(configureBloopInstall)
-    ()
+    bloopConfig
   }
 
-  private[this] val incompatibleConfigurations = Set[String](
-    "incrementalScalaAnalysisElements",
-    "incrementalScalaAnalysisFormain",
-    "incrementalScalaAnalysisFortest",
-    "incrementalScalaAnalysisForintegTest",
-    "incrementalScalaAnalysisForjmh",
-    "zinc"
-  )
-
-  def extendCompatibleConfigurationAfterEvaluate(
+  /**
+   * Makes the input configuration extend valid compatible configurations.
+   * Note that if extendConfigNames is empty, all resolvable and non-whitelisted
+   * configurations will be extended automatically.
+   */
+  private def extendCompatibleConfigurationAfterEvaluate(
       project: Project,
-      bloopConfig: Configuration
+      bloopSourceSetConfig: Configuration,
+      compatibleConfigNames: Set[String],
+      incompatibleConfigNames: Set[String]
   ): Unit = {
     // Use consumer instead of Scala closure because of Scala 2.11 compat
     val extendConfigurationIfCompatible = new java.util.function.Consumer[Configuration] {
       def accept(config: Configuration): Unit = {
         if (
-          config != bloopConfig && config.isCanBeResolved &&
-          !incompatibleConfigurations.contains(config.getName())
+          config != bloopSourceSetConfig &&
+          config.isCanBeResolved &&
+          (compatibleConfigNames.isEmpty || compatibleConfigNames.contains(config.getName())) &&
+          !incompatibleConfigNames.contains(config.getName())
         ) {
-          bloopConfig.extendsFrom(config)
+          bloopSourceSetConfig.extendsFrom(config)
         }
       }
     }
 
-    // Important to do this after evaluation so Gradle can add all the necessary project configuration before we extend them
-    project.afterEvaluate(
-      // Use Action instead of Scala closure because of Scala 2.11 compat
-      new org.gradle.api.Action[Project] {
-        def execute(project: Project): Unit = {
-          project.getConfigurations.forEach(extendConfigurationIfCompatible)
-        }
-      }
-    )
+    project.getConfigurations.forEach(extendConfigurationIfCompatible)
   }
 }

--- a/src/main/scala/bloop/integrations/gradle/BloopPlugin.scala
+++ b/src/main/scala/bloop/integrations/gradle/BloopPlugin.scala
@@ -1,15 +1,16 @@
 package bloop.integrations.gradle
 
+import scala.collection.JavaConverters._
+
 import bloop.integrations.gradle.syntax._
-import bloop.integrations.gradle.tasks.PluginUtils
 import bloop.integrations.gradle.tasks.BloopInstallTask
 import bloop.integrations.gradle.tasks.ConfigureBloopInstallTask
-import scala.collection.JavaConverters._
+import bloop.integrations.gradle.tasks.PluginUtils
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.tasks.SourceSet
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.tasks.SourceSet
 
 /**
  * Main entry point of the gradle bloop plugin.

--- a/src/main/scala/bloop/integrations/gradle/syntax.scala
+++ b/src/main/scala/bloop/integrations/gradle/syntax.scala
@@ -123,4 +123,12 @@ object syntax {
   implicit class FileExtension(file: File) {
     def /(child: String): File = new File(file, child)
   }
+
+  def capitalize(x: String): String = Option(x) match {
+    case Some(s) if s.nonEmpty => s.head.toUpper + s.tail
+    case _ => x
+  }
+
+  def generateBloopConfigName(sourceSet: SourceSet): String =
+    s"bloop${capitalize(sourceSet.getName())}Config"
 }

--- a/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
+++ b/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
@@ -3632,7 +3632,10 @@ abstract class ConfigGenerationSuite extends BaseConfigSuite {
         |
         |configurations {
         |    scalaCompilerPlugin
-        |    bloopConfig.extendsFrom(scalaCompilerPlugin)
+        |}
+        |
+        |bloop {
+        |    extendUserConfigurations = [configurations.scalaCompilerPlugin.name]
         |}
         |
         |dependencies {


### PR DESCRIPTION
The previous solution worked, but it was not ideal because it introduced the concept of a `bloopConfig` that had to extend all the configurations in the project (even across different source sets, e.g. main, test, integTest, etc.).

This is awkward because the plugin generates a bloop config per source set. So, if we have one bloop config extending all configurations from all source sets, and then depending on that when generating bloop config per source set, we're running into a lot of repeated resolutions to produce the necessary artifacts and the resolution config section contains a lot more artifacts than it should (e.g. foo.json and foo-test.json would contain the same set of artifacts). Also, in theory, this approach could also cause Gradle to add the wrong artifact version because it would need reconciling all artifact across all source sets is more likely to produce different results. This is a theoretical point, but it'd be nice to avoid it.

So, the fix to all of this is to make a `bloopConfig` configuration per source set. For example, the main source set gets a `bloopConfigMain` configuration that extends from some default configurations that we care about for Java/Scala plugins.

(In the Android world, there are no sourcesets, but "variants" so we fallback on the previous behavior and depend on all the sources for `bloopConfigAndroid`, a config that exists only in Android projects and that adds the artifacts of all the project variants -- this is the behavior one expects, and in this case we extend from all the configurations in the variants for backwards compatibility.)

To make the process more customizable for end users, I've also added a new property in the bloop configuration that lets users specify the extra configurations that should be extended per source set:

```
bloop {
  extendUserConfigurations = [configurations.myCustomConfig.name]
}
```

This way, users have control over the configurations that should also contribute artifacts to the resolution section in the bloop config. This is nice and better than the previous approach.